### PR TITLE
expose client request - [feature request]

### DIFF
--- a/glightning/lightning.go
+++ b/glightning/lightning.go
@@ -44,6 +44,10 @@ func (l *Lightning) IsUp() bool {
 	return l.isUp && l.client.IsUp()
 }
 
+func (l *Lightning) Request(m jrpc2.Method, resp interface{}) error {
+	return l.client.Request(m, resp)
+}
+
 type ListPeersRequest struct {
 	PeerId string `json:"id,omitempty"`
 	Level  string `json:"level,omitempty"`
@@ -791,7 +795,7 @@ func (l *Lightning) SendPay(route []RouteHop, paymentHash, label string, msat ui
 		PaymentHash:   paymentHash,
 		Label:         label,
 		MilliSatoshis: msat,
-		Bolt11: bolt11,
+		Bolt11:        bolt11,
 	}, &result)
 	return &result, err
 }


### PR DESCRIPTION
This will allow a running instance to call clightning RPC methods that have not yet been implemented in glightning.  Also, since methods can be added via plugins, you can call a plugin's RPC method allowing you to build on top of existing plugins