### PR TITLE
Add fundchannel_* and tx* commands to RPC interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 todos
+tags

--- a/examples/rpc/example.go
+++ b/examples/rpc/example.go
@@ -12,7 +12,8 @@ func main() {
 	id := "03a13a469bae4785e27fae24e7664e648cfdb976b97f95c694dea5e55e7d302846"
 	sats := glightning.NewAmount(600000)
 	feerate := glightning.NewFeeRateByDirective(glightning.SatPerKiloSipa, glightning.Urgent)
-	result, err := lone.FundChannelExt(id, sats, feerate, true)
+	minConf := uint16(1)
+	result, err := lone.FundChannelExt(id, sats, feerate, true, &minConf)
 	if err != nil {
 		panic(err)
 	}

--- a/glightning/lightning_test.go
+++ b/glightning/lightning_test.go
@@ -803,7 +803,7 @@ func TestTxPrepare(t *testing.T) {
 	}
 
 	assert.Equal(t, &glightning.TxResult{
-		Tx: "0200000001060528291e1039a5a2e071ab88ffca8cb9655481f62108dff2e87a1aa139b6450000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a01000000160014e1cfb78798b16dd8f0b05b540f853d07ac5c555200000000",
+		Tx:   "0200000001060528291e1039a5a2e071ab88ffca8cb9655481f62108dff2e87a1aa139b6450000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a01000000160014e1cfb78798b16dd8f0b05b540f853d07ac5c555200000000",
 		TxId: "cec03e956f3761624f176d62428d9e2cd51cb923258e00e17a34fc49b0da6dde",
 	}, result)
 }
@@ -823,7 +823,7 @@ func TestTxSend(t *testing.T) {
 	}
 
 	assert.Equal(t, &glightning.TxResult{
-		Tx: "0200000001f56ad611189c96c9ae9499d61872e590a3ba4d55760f7663b0642d81c2b1880d0000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a010000001600146ea01d6c5aaa643076902d1c8b026e9eb47b32c000000000",
+		Tx:   "0200000001f56ad611189c96c9ae9499d61872e590a3ba4d55760f7663b0642d81c2b1880d0000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a010000001600146ea01d6c5aaa643076902d1c8b026e9eb47b32c000000000",
 		TxId: "c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed",
 	}, result)
 }
@@ -842,7 +842,7 @@ func TestTxDiscard(t *testing.T) {
 	}
 
 	assert.Equal(t, &glightning.TxResult{
-		Tx: "0200000001f56ad611189c96c9ae9499d61872e590a3ba4d55760f7663b0642d81c2b1880d0000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a010000001600146ea01d6c5aaa643076902d1c8b026e9eb47b32c000000000",
+		Tx:   "0200000001f56ad611189c96c9ae9499d61872e590a3ba4d55760f7663b0642d81c2b1880d0000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a010000001600146ea01d6c5aaa643076902d1c8b026e9eb47b32c000000000",
 		TxId: "c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed",
 	}, result)
 }
@@ -937,7 +937,7 @@ func TestFundChannel(t *testing.T) {
 	id := "03fb0b8a395a60084946eaf98cfb5a81ea010e0307eaf368ba21e7d6bcf0e4dc41"
 	amount := 90000
 
-	req := fmt.Sprintf(`{"jsonrpc":"2.0","method":"fundchannel","params":{"announce":false,"feerate":"500perkw","id":"%s","satoshi":%d},"id":%d}`, id, amount, 1)
+	req := fmt.Sprintf(`{"jsonrpc":"2.0","method":"fundchannel","params":{"announce":false,"feerate":"500perkw","id":"%s","satoshi":"%d"},"id":%d}`, id, amount, 1)
 	resp := wrapResult(1, `{
   "tx": "0200000000010153bcd4cfabb72750bb8d16fc711c91b30215957549a0a93370f50475fa9457570100000000ffffffff02ffffff0000000000220020b2c1a13de4a5926ed48601626e281a171d0cdb548fddc4e7cc8cdc9d982a2368a0c79a3a00000000160014d952a5ff3c78ca2c48fd8e2b4ae0699887dd166e0247304402206a781a53902e6526686b9ecc79f7287d372d11614dc094789f05f843458e703e022041cc1f5f7e2526d415b44563c80b80d9ce808310eaf8a73fbead45a0238b01e0012102cf978ae73c98d6e8e73b384b217c13180fd75cd867f5d9daf19624ecebf5fc0a00000000",
   "txid": "7c158044dd655057ea344924e135f8c5e5cffa8f583ccd81650f2b82057f0b5c",
@@ -948,7 +948,7 @@ func TestFundChannel(t *testing.T) {
 	feeRate := glightning.NewFeeRate(glightning.SatPerKiloSipa, 500)
 	lightning, requestQ, replyQ := startupServer(t)
 	go runServerSide(t, req, resp, replyQ, requestQ)
-	result, err := lightning.FundChannelExt(id, sats, feeRate, false)
+	result, err := lightning.FundChannelExt(id, sats, feeRate, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -967,9 +967,9 @@ func TestFundChannel(t *testing.T) {
 `)
 	sats = &glightning.SatoshiAmount{Amount: uint64(amount)}
 	feeRate = glightning.NewFeeRateByDirective(glightning.SatPerKiloByte, glightning.Urgent)
-	req = fmt.Sprintf(`{"jsonrpc":"2.0","method":"fundchannel","params":{"announce":true,"feerate":"urgent","id":"%s","satoshi":%d},"id":%d}`, id, amount, 2)
+	req = fmt.Sprintf(`{"jsonrpc":"2.0","method":"fundchannel","params":{"announce":true,"feerate":"urgent","id":"%s","satoshi":"%d"},"id":%d}`, id, amount, 2)
 	go runServerSide(t, req, resp, replyQ, requestQ)
-	_, err = lightning.FundChannelExt(id, sats, feeRate, true)
+	_, err = lightning.FundChannelExt(id, sats, feeRate, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -985,7 +985,7 @@ func TestFundChannel(t *testing.T) {
 	go runServerSide(t, req, resp, replyQ, requestQ)
 	sats = &glightning.SatoshiAmount{SendAll: true}
 	feeRate = glightning.NewFeeRate(glightning.SatPerKiloByte, uint(300))
-	_, err = lightning.FundChannelExt(id, sats, feeRate, true)
+	_, err = lightning.FundChannelExt(id, sats, feeRate, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1001,7 +1001,7 @@ func TestFundChannel(t *testing.T) {
 	feeRate = glightning.NewFeeRateByDirective(glightning.SatPerKiloByte, glightning.Urgent)
 	req = fmt.Sprintf(`{"jsonrpc":"2.0","method":"fundchannel","params":{"announce":false,"feerate":"urgent","id":"%s","satoshi":"all"},"id":%d}`, id, 4)
 	go runServerSide(t, req, resp, replyQ, requestQ)
-	_, err = lightning.FundChannelExt(id, sats, feeRate, false)
+	_, err = lightning.FundChannelExt(id, sats, feeRate, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/glightning/lightning_test.go
+++ b/glightning/lightning_test.go
@@ -784,6 +784,69 @@ func TestWithdrawAll(t *testing.T) {
 	}, result)
 }
 
+func TestTxPrepare(t *testing.T) {
+	destination := "bcrt1qeyyk6sl5pr49ycpqyckvmttus5ttj25pd0zpvg"
+	amount := glightning.NewAmount(100000)
+	feerate := glightning.NewFeeRate(glightning.SatPerKiloSipa, 243)
+	minConf := uint16(1)
+	req := `{"jsonrpc":"2.0","method":"txprepare","params":{"destination":"bcrt1qeyyk6sl5pr49ycpqyckvmttus5ttj25pd0zpvg","feerate":"243perkw","minconf":1,"satoshi":"100000"},"id":1}`
+	resp := wrapResult(1, `{
+   "unsigned_tx" : "0200000001060528291e1039a5a2e071ab88ffca8cb9655481f62108dff2e87a1aa139b6450000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a01000000160014e1cfb78798b16dd8f0b05b540f853d07ac5c555200000000",
+   "txid" : "cec03e956f3761624f176d62428d9e2cd51cb923258e00e17a34fc49b0da6dde"
+}`)
+
+	lightning, requestQ, replyQ := startupServer(t)
+	go runServerSide(t, req, resp, replyQ, requestQ)
+	result, err := lightning.PrepareTx(destination, amount, feerate, &minConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, &glightning.TxResult{
+		Tx: "0200000001060528291e1039a5a2e071ab88ffca8cb9655481f62108dff2e87a1aa139b6450000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a01000000160014e1cfb78798b16dd8f0b05b540f853d07ac5c555200000000",
+		TxId: "cec03e956f3761624f176d62428d9e2cd51cb923258e00e17a34fc49b0da6dde",
+	}, result)
+}
+
+func TestTxSend(t *testing.T) {
+	req := `{"jsonrpc":"2.0","method":"txsend","params":{"txid":"c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed"},"id":1}`
+	resp := wrapResult(1, `{
+   "unsigned_tx" : "0200000001f56ad611189c96c9ae9499d61872e590a3ba4d55760f7663b0642d81c2b1880d0000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a010000001600146ea01d6c5aaa643076902d1c8b026e9eb47b32c000000000",
+   "txid" : "c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed"
+}`)
+
+	lightning, requestQ, replyQ := startupServer(t)
+	go runServerSide(t, req, resp, replyQ, requestQ)
+	result, err := lightning.SendTx("c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, &glightning.TxResult{
+		Tx: "0200000001f56ad611189c96c9ae9499d61872e590a3ba4d55760f7663b0642d81c2b1880d0000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a010000001600146ea01d6c5aaa643076902d1c8b026e9eb47b32c000000000",
+		TxId: "c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed",
+	}, result)
+}
+
+func TestTxDiscard(t *testing.T) {
+	req := `{"jsonrpc":"2.0","method":"txdiscard","params":{"txid":"c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed"},"id":1}`
+	resp := wrapResult(1, `{
+   "unsigned_tx" : "0200000001f56ad611189c96c9ae9499d61872e590a3ba4d55760f7663b0642d81c2b1880d0000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a010000001600146ea01d6c5aaa643076902d1c8b026e9eb47b32c000000000",
+   "txid" : "c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed"
+}`)
+	lightning, requestQ, replyQ := startupServer(t)
+	go runServerSide(t, req, resp, replyQ, requestQ)
+	result, err := lightning.DiscardTx("c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, &glightning.TxResult{
+		Tx: "0200000001f56ad611189c96c9ae9499d61872e590a3ba4d55760f7663b0642d81c2b1880d0000000000ffffffff02a086010000000000160014c9096d43f408ea526020262ccdad7c8516b92a81d86a042a010000001600146ea01d6c5aaa643076902d1c8b026e9eb47b32c000000000",
+		TxId: "c139ff2ce1c1e1056429c1527262d56da2be096559f554e061da18ee72d5c5ed",
+	}, result)
+}
+
 func TestClose(t *testing.T) {
 	id := "03fb0b8a395a60084946eaf98cfb5a81ea010e0307eaf368ba21e7d6bcf0e4dc41"
 	req := `{"jsonrpc":"2.0","method":"close","params":{"id":"03fb0b8a395a60084946eaf98cfb5a81ea010e0307eaf368ba21e7d6bcf0e4dc41"},"id":1}`

--- a/glightning/lightning_test.go
+++ b/glightning/lightning_test.go
@@ -746,7 +746,7 @@ func TestGetRoute(t *testing.T) {
 
 func TestWithdraw(t *testing.T) {
 	addr := "bcrt1qx5yjs8y4vm929ykzpmm8r7yxwakyvjwmyc5mkm"
-	req := `{"jsonrpc":"2.0","method":"withdraw","params":{"destination":"bcrt1qx5yjs8y4vm929ykzpmm8r7yxwakyvjwmyc5mkm","feerate":"125perkb","satoshi":500000},"id":1}`
+	req := `{"jsonrpc":"2.0","method":"withdraw","params":{"destination":"bcrt1qx5yjs8y4vm929ykzpmm8r7yxwakyvjwmyc5mkm","feerate":"125perkb","satoshi":"500000"},"id":1}`
 	resp := wrapResult(1, `{
   "tx": "020000000001012a62fd17c6b13b7d89df7bbceb9baa79ab937223887c9c69b05fefc9288a2d640000000000ffffffff0250c30000000000001600143509281c9566caa292c20ef671f886776c4649db9d3aff00000000001600142e7dfaf485fba60010bfb37c99fc93b8bb42ad0202483045022100b99e4231fcf98dc2f94d88094b63dc12fc0ba7c125dc78df1f7a50bfca726b8a02204639577a20f39830d63dfefcfc85f134f0d8128c55a2833775bb906957a0fa86012103d5aea229d81a06e576dfcf71db13670422b22dd1093cddc01269a5596fb0c7d100000000",
   "txid": "f80423d5daed70d31585e597d8e1c0d191a5f2d8050a11dee730f7727c5abd9c"
@@ -754,7 +754,7 @@ func TestWithdraw(t *testing.T) {
 	lightning, requestQ, replyQ := startupServer(t)
 	go runServerSide(t, req, resp, replyQ, requestQ)
 	feerate := glightning.NewFeeRate(glightning.SatPerKiloByte, 125)
-	result, err := lightning.Withdraw(addr, glightning.NewAmount(500000), feerate)
+	result, err := lightning.Withdraw(addr, glightning.NewAmount(500000), feerate, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -774,7 +774,7 @@ func TestWithdrawAll(t *testing.T) {
 	lightning, requestQ, replyQ := startupServer(t)
 	go runServerSide(t, req, resp, replyQ, requestQ)
 	feerate := glightning.NewFeeRate(glightning.SatPerKiloByte, 125)
-	result, err := lightning.Withdraw(addr, glightning.NewAllAmount(), feerate)
+	result, err := lightning.Withdraw(addr, glightning.NewAllAmount(), feerate, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Some cleanups plus the new RPC calls:
- `txprepare`
- `txsend`
- `txdiscard`
- `fundchannel_start`
- `fundchannel_continue`
- `fundchannel_cancel`

This should be most of the primitives necessary to do a 'one step' multifundchannel command, etc.