### PR TITLE
add config network parameter

### DIFF
--- a/glightning/plugin.go
+++ b/glightning/plugin.go
@@ -583,6 +583,7 @@ type Config struct {
 	LightningDir string `json:"lightning-dir"`
 	RpcFile      string `json:"rpc-file"`
 	Startup      bool   `json:"startup,omitempty"`
+	Network      string `json:"network,omitempty"`
 }
 
 type InitMethod struct {

--- a/glightning/plugin_test.go
+++ b/glightning/plugin_test.go
@@ -125,12 +125,13 @@ func TestInit(t *testing.T) {
 		assert.Equal(t, "rpc.file", config.RpcFile)
 		assert.Equal(t, "dirforlightning", config.LightningDir)
 		assert.Equal(t, true, config.Startup)
+		assert.Equal(t, "testnet", config.Network)
 	})
 	plugin := glightning.NewPlugin(initTestFn)
 	plugin.RegisterOption(glightning.NewOption("greeting", "How you'd like to be called", "Mary"))
 	plugin.RegisterMethod(glightning.NewRpcMethod(NewHiMethod(plugin), "Send a greeting."))
 
-	initJson := "{\"jsonrpc\":\"2.0\",\"method\":\"init\",\"params\":{\"options\":{\"greeting\":\"Jenny\"},\"configuration\":{\"rpc-file\":\"rpc.file\",\"startup\":true,\"lightning-dir\":\"dirforlightning\"}},\"id\":1}\n\n"
+	initJson := "{\"jsonrpc\":\"2.0\",\"method\":\"init\",\"params\":{\"options\":{\"greeting\":\"Jenny\"},\"configuration\":{\"rpc-file\":\"rpc.file\",\"startup\":true,\"network\":\"testnet\",\"lightning-dir\":\"dirforlightning\"}},\"id\":1}\n\n"
 
 	expectedJson := "{\"jsonrpc\":\"2.0\",\"result\":\"ok\",\"id\":1}"
 	runTest(t, plugin, initJson, expectedJson)


### PR DESCRIPTION
plugins break [here](https://github.com/ElementsProject/lightning/commit/14247283b2934d0dc352f09e3dc4c389097008d6#diff-d7945e0ea0fc3a128a17dec5e0ff98ddR1052) with the addtion of `network` to the config object