### PR TITLE
listfunds: Moved from array of struct to array of pointers.

### DIFF
--- a/glightning/lightning.go
+++ b/glightning/lightning.go
@@ -2141,9 +2141,9 @@ type Forwarding struct {
 }
 
 // List all forwarded payments and their information
-func (l *Lightning) ListForwards() ([]Forwarding, error) {
+func (l *Lightning) ListForwards() ([]*Forwarding, error) {
 	var result struct {
-		Forwards []Forwarding `json:"forwards"`
+		Forwards []*Forwarding `json:"forwards"`
 	}
 	err := l.client.Request(&ListForwardsRequest{}, &result)
 	return result.Forwards, err

--- a/glightning/tests/interop_test.go
+++ b/glightning/tests/interop_test.go
@@ -396,6 +396,22 @@ func TestListTransactions(t *testing.T) {
 	assert.Equal(t, len(trans), 2)
 }
 
+func TestListFunds(t *testing.T) {
+	short(t)
+
+	testDir, dataDir, btcPid, btc := Init(t)
+	defer CleanUp(testDir)
+	l1 := LnNode(t, testDir, dataDir, btcPid, "one", nil)
+
+	fundNode(t, "1.0", l1, btc)
+	fundNode(t, "1.0", l1, btc)
+	waitToSync(l1)
+	funds, err := l1.rpc.ListFunds()
+	check(t, err)
+	assert.Equal(t, len(funds.Channels), 0)
+}
+
+
 func fundNode(t *testing.T, amount string, n *Node, b *gbitcoin.Bitcoin) {
 	addr, err := n.rpc.NewAddr()
 	check(t, err)

--- a/jrpc2/client_test.go
+++ b/jrpc2/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -110,7 +111,7 @@ func (s *ServerSubtractString) New() interface{} {
 }
 
 func (s *ServerSubtractString) Call() (jrpc2.Result, error) {
-	return string(s.Minuend - s.Subtrahend), nil
+	return fmt.Sprintf("%d", (s.Minuend - s.Subtrahend)), nil
 }
 
 // send a response with a result of a different type than


### PR DESCRIPTION
I noted that there is a mistake in the API, almost all the arrays are arrays of pointers, but in the case of the `listfunds` it is returned an array of the struct.

There is also a test written a couple of weeks ago, because I noted a crash in the library but I was not able to catch it. Test is always good I think :)