### PR TITLE
Supported x32 architecture.

### DIFF
--- a/glightning/lightning.go
+++ b/glightning/lightning.go
@@ -417,7 +417,6 @@ type Channel struct {
 	ShortChannelId           string `json:"short_channel_id"`
 	IsPublic                 bool   `json:"public"`
 	Satoshis                 uint64 `json:"satoshis"`
-	AmountMsat               string `json:"amount_msat"`
 	MessageFlags             uint   `json:"message_flags"`
 	ChannelFlags             uint   `json:"channel_flags"`
 	IsActive                 bool   `json:"active"`
@@ -425,8 +424,6 @@ type Channel struct {
 	BaseFeeMillisatoshi      uint64 `json:"base_fee_millisatoshi"`
 	FeePerMillionth          uint64 `json:"fee_per_millionth"`
 	Delay                    uint   `json:"delay"`
-	HtlcMinimumMilliSatoshis string `json:"htlc_minimum_msat"`
-	HtlcMaximumMilliSatoshis string `json:"htlc_maximum_msat"`
 }
 
 // Get channel by {shortChanId}

--- a/jrpc2/client.go
+++ b/jrpc2/client.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"math"
 	"sync/atomic"
 	"time"
 )
@@ -23,7 +24,7 @@ import (
 type Client struct {
 	requestQueue   chan *Request
 	pending        sync.Map // map[string]chan *RawResponse
-	requestCounter int64
+	requestCounter uint32
 	shutdown       bool
 	timeout        time.Duration
 }
@@ -226,6 +227,9 @@ func handleReply(rawResp *RawResponse, resp interface{}) error {
 
 // for now, use a counter as the id for requests
 func (c *Client) NextId() *Id {
-	val := atomic.AddInt64(&c.requestCounter, 1)
+	if c.requestCounter == math.MaxUint32 {
+		atomic.StoreUint32(&c.requestCounter, 0)
+	}
+	val := atomic.AddUint32(&c.requestCounter, 1)
 	return NewIdAsInt(val)
 }

--- a/jrpc2/jsonrpc2.go
+++ b/jrpc2/jsonrpc2.go
@@ -28,7 +28,7 @@ const InternalErr = -32603
 // 'actual' type of it so when we send it back over the
 // wire, we don't confuse the other side.
 type Id struct {
-	intVal int64
+	intVal uint32
 	strVal string
 }
 
@@ -52,11 +52,11 @@ func (id *Id) UnmarshalJSON(data []byte) error {
 		id.strVal = string(data[1 : len(data)-1])
 		return nil
 	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-		val, err := strconv.ParseInt(string(data), 10, 64)
+		val, err := strconv.ParseUint(string(data), 10, 32)
 		if err != nil {
 			return NewError(nil, InvalidRequest, fmt.Sprintf("Invalid Id value: %s", string(data)))
 		}
-		id.intVal = val
+		id.intVal = uint32(val)
 		return nil
 	case '{': // objects not allowed!
 		fallthrough
@@ -75,7 +75,7 @@ func (id Id) String() string {
 	if id.strVal != "" {
 		return id.strVal
 	}
-	return strconv.FormatInt(id.intVal, 10)
+	return strconv.FormatInt(int64(id.intVal), 10)
 }
 
 func NewId(val string) *Id {
@@ -84,7 +84,7 @@ func NewId(val string) *Id {
 	}
 }
 
-func NewIdAsInt(val int64) *Id {
+func NewIdAsInt(val uint32) *Id {
 	return &Id{
 		intVal: val,
 	}


### PR DESCRIPTION
On my Raspberry pi 3b I received the following error:

```
➜  ~ lightningd --disable-plugin bcli --daemon
➜  ~ panic: unaligned 64-bit atomic operation

goroutine 29 [running]:
runtime/internal/atomic.panicUnaligned()
	/home/pi/compilers/go/src/runtime/internal/atomic/unaligned.go:8 +0x24
runtime/internal/atomic.Xadd64(0x1cb637c, 0x1)
	/home/pi/compilers/go/src/runtime/internal/atomic/atomic_arm.s:256 +0x14
github.com/niftynei/glightning/jrpc2.(*Client).NextId(...)
	/home/pi/github/go-metrics-reported/vendor/github.com/niftynei/glightning/jrpc2/client.go:229
github.com/niftynei/glightning/jrpc2.(*Client).Request(0x1cb6360, {0x279d6c, 0x3c2db4}, {0x207010, 0x1e0e080})
	/home/pi/github/go-metrics-reported/vendor/github.com/niftynei/glightning/jrpc2/client.go:166 +0x40
github.com/niftynei/glightning/glightning.(*Lightning).GetInfo(...)
	/home/pi/github/go-metrics-reported/vendor/github.com/niftynei/glightning/glightning/lightning.go:1060
github.com/OpenLNMetrics/go-metrics-reported/internal/plugin.(*MetricOne).OnInit(0x1c6a050, 0x1c988d8)
	/home/pi/github/go-metrics-reported/internal/plugin/metrics_one.go:307 +0x50
github.com/OpenLNMetrics/go-metrics-reported/internal/plugin.(*MetricsPlugin).RegisterOneTimeEvt.func1.1(0x3b1350, {0x27d870, 0x1c6a050})
	/home/pi/github/go-metrics-reported/internal/plugin/plugin.go:118 +0x30
created by github.com/OpenLNMetrics/go-metrics-reported/internal/plugin.(*MetricsPlugin).RegisterOneTimeEvt.func1
	/home/pi/github/go-metrics-reported/internal/plugin/plugin.go:117 +0xcc
```

This PR will fix it, at least it includes a workaround.